### PR TITLE
[CLOUD-1337] Introduce the babylon vault service endpoint resource

### DIFF
--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_babylonawsiam.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_babylonawsiam.go
@@ -7,8 +7,8 @@ import (
 	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
 )
 
-const SERVICE_CONNECTION_TYPE string = "babylon-service-endpoint-aws-iam"
-const DEFAULT_SESSION_NAME string = "azure-pipelines-task"
+const BABYLON_AWS_IAM_SERVICE_CONNECTION_TYPE string = "babylon-service-endpoint-aws-iam"
+const BABYLON_AWS_IAM_DEFAULT_SESSION_NAME string = "azure-pipelines-task"
 
 func ResourceServiceEndpointBabylonAwsIam() *schema.Resource {
 	r := genBaseServiceEndpointResource(flattenServiceEndpointBabylonAwsIam, expandServiceEndpointBabylonAwsIam)
@@ -33,7 +33,7 @@ func ResourceServiceEndpointBabylonAwsIam() *schema.Resource {
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Session name to be used when assuming the role. The session name should match the one specified in the trust policies of the regional IAM roles.",
-		Default:     DEFAULT_SESSION_NAME,
+		Default:     BABYLON_AWS_IAM_DEFAULT_SESSION_NAME,
 	}
 	secretHashKey, secretHashSchema := tfhelper.GenerateSecreteMemoSchema("password")
 	r.Schema[secretHashKey] = secretHashSchema
@@ -53,7 +53,7 @@ func expandServiceEndpointBabylonAwsIam(d *schema.ResourceData) (*serviceendpoin
 		Scheme: converter.String("UsernamePassword"),
 	}
 	serviceEndpoint.Data = &map[string]string{}
-	serviceEndpoint.Type = converter.String(SERVICE_CONNECTION_TYPE)
+	serviceEndpoint.Type = converter.String(BABYLON_AWS_IAM_SERVICE_CONNECTION_TYPE)
 	serviceEndpoint.Url = converter.String("https://aws.amazon.com/")
 	return serviceEndpoint, projectID, nil
 }

--- a/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_babylonvault.go
+++ b/azuredevops/internal/service/serviceendpoint/resource_serviceendpoint_babylonvault.go
@@ -1,0 +1,64 @@
+package serviceendpoint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/serviceendpoint"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/converter"
+	"github.com/microsoft/terraform-provider-azuredevops/azuredevops/internal/utils/tfhelper"
+)
+
+const BABYLON_VAULT_SERVICE_CONNECTION_TYPE string = "babylon-service-endpoint-vault"
+
+func ResourceServiceEndpointBabylonVault() *schema.Resource {
+	r := genBaseServiceEndpointResource(flattenServiceEndpointBabylonVault, expandServiceEndpointBabylonVault)
+	r.Schema["url"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+		ValidateFunc: func(i interface{}, key string) (_ []string, errors []error) {
+			url, ok := i.(string)
+			if !ok {
+				errors = append(errors, fmt.Errorf("expected type of %q to be string", key))
+				return
+			}
+			if strings.HasSuffix(url, "/") {
+				errors = append(errors, fmt.Errorf("%q should not end with slash, got %q.", key, url))
+				return
+			}
+			return validation.IsURLWithHTTPorHTTPS(url, key)
+		},
+		Description: "Url for the Vault Server",
+	}
+
+	r.Schema["vault_role"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Vault role to log in as",
+	}
+	return r
+}
+
+// Convert internal Terraform data structure to an AzDO data structure
+func expandServiceEndpointBabylonVault(d *schema.ResourceData) (*serviceendpoint.ServiceEndpoint, *string, error) {
+	serviceEndpoint, projectID := doBaseExpansion(d)
+	serviceEndpoint.Authorization = &serviceendpoint.EndpointAuthorization{
+		Parameters: &map[string]string{},
+		Scheme:     converter.String("None"),
+	}
+	serviceEndpoint.Data = &map[string]string{"vaultRole": d.Get("vault_role").(string)}
+	serviceEndpoint.Type = converter.String(BABYLON_VAULT_SERVICE_CONNECTION_TYPE)
+	serviceEndpoint.Url = converter.String(d.Get("url").(string))
+	return serviceEndpoint, projectID, nil
+}
+
+// Convert AzDO data structure to internal Terraform data structure
+func flattenServiceEndpointBabylonVault(d *schema.ResourceData, serviceEndpoint *serviceendpoint.ServiceEndpoint, projectID *string) {
+	doBaseFlattening(d, serviceEndpoint, projectID)
+	tfhelper.HelpFlattenSecret(d, "password")
+
+	d.Set("url", *serviceEndpoint.Url)
+	d.Set("vault_role", (*serviceEndpoint.Data)["vaultRole"])
+}

--- a/azuredevops/provider.go
+++ b/azuredevops/provider.go
@@ -50,6 +50,7 @@ func Provider() *schema.Provider {
 			"azuredevops_serviceendpoint_npm":               serviceendpoint.ResourceServiceEndpointNpm(),
 			"azuredevops_serviceendpoint_genericwebhook":    serviceendpoint.ResourceServiceEndpointGenericWebhook(),
 			"azuredevops_serviceendpoint_babylonawsiam":     serviceendpoint.ResourceServiceEndpointBabylonAwsIam(),
+			"azuredevops_serviceendpoint_babylonvault":      serviceendpoint.ResourceServiceEndpointBabylonVault(),
 			"azuredevops_git_repository":                    git.ResourceGitRepository(),
 			"azuredevops_user_entitlement":                  memberentitlementmanagement.ResourceUserEntitlement(),
 			"azuredevops_group_membership":                  graph.ResourceGroupMembership(),

--- a/azuredevops/provider_test.go
+++ b/azuredevops/provider_test.go
@@ -31,6 +31,7 @@ func TestProvider_HasChildResources(t *testing.T) {
 		"azuredevops_serviceendpoint_kubernetes",
 		"azuredevops_serviceendpoint_aws",
 		"azuredevops_serviceendpoint_babylonawsiam",
+		"azuredevops_serviceendpoint_babylonvault",
 		"azuredevops_serviceendpoint_genericwebhook",
 		"azuredevops_serviceendpoint_artifactory",
 		"azuredevops_serviceendpoint_sonarqube",


### PR DESCRIPTION
## Example resource
```hcl
resource "azuredevops_serviceendpoint_babylonvault" "serviceendpoint" {
  project_id            = data.azuredevops_project.manual.id
  service_endpoint_name = "my-service-connection-vault-tris"
  url                   = "https://vault.dev.ops.babylontech.co.uk"
  vault_role            = "devadmin"
  description           = "Managed by Terraform"
}
```

## All Submissions:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] I have updated the documentation accordingly.
* [ ] I have added tests to cover my changes.
* [ ] All new and existing tests passed.
* [ ] My code follows the code style of this project.
* [ ] I ran lint checks locally prior to submission.
* [ ] Have you checked to ensure there aren't other open PRs for the same update/change?

## What about the current behavior has changed?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:

## Does this introduce a change to `go.mod`, `go.sum` or `vendor/`?

- [ ] Yes
- [ ] No

<!-- If this introduces a change to these files, please elaborate on why -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Any relevant logs, error output, etc?

(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->