### PR TITLE
[SRE-117] Update terraform version to reflect azure-terraform bump

### DIFF
--- a/babylon/Dockerfile.sha
+++ b/babylon/Dockerfile.sha
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.13.3
+FROM hashicorp/terraform:0.15.1
 
 COPY babylon/terraform.d /usr/local/share/terraform/
 COPY babylon/.terraformrc /opt/.terraformrc


### PR DESCRIPTION
Terraform version in `azure-terraform` was locked to 0.15.1 ages ago: https://github.com/babylonhealth/azure-terraform/pull/665

This should allow to use [terraform-no-auth](https://github.com/babylonhealth/azure-terraform/blob/master/bin/terraform-no-auth) for local plan since right now it fails with:

```console
…/azure-terraform/pc2/platform-monorepo-aws-proof-of-concept  SRE-117-platform-monorepo-aws-proof-of-concept [$] on 🅰 (eu-west-2) ☸ preprod-us ⩔ dev-uk at 15:42:54 ✖ 1 ❯ USING_PROD=yep ../../bin/terraform-no-auth plan -no-color 
ERRO[0000] The currently installed version of Terraform (0.13.3) is not compatible with the version Terragrunt requires (= 0.15.1). 
ERRO[0000] Unable to determine underlying exit code, so Terragrunt will exit with error code 1 
```