### PR TITLE
[SRE-537] We can't stay on Terraform 0.13.3 forever

### DIFF
--- a/babylon/Dockerfile.sha
+++ b/babylon/Dockerfile.sha
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.13.3
+FROM hashicorp/terraform:0.15.1
 
 COPY babylon/terraform.d /usr/local/share/terraform/
 COPY babylon/.terraformrc /opt/.terraformrc


### PR DESCRIPTION
This actually breaks applying the `/pc2/platform-monorepo-aws-nonprod` dir of babylonhealth/azure-terraform. I have no idea how CLOUD-7174 is even tangentially related to the Terraform version, as it looks like it describes a feature in the AzDO provider itself.

Undoes #7 to reinstate #5. I'll cut v0.3.0-babylon.0 of the image to avoid breaking pipelines.